### PR TITLE
ci(deploy): fix the if condition of the push job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
 
   push:
     needs: version
-    if: ${{ needs.version.outputs.hasNextVersion }}
+    if: needs.version.outputs.hasNextVersion == 'true'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
The hasNextVersion output is a string value which is either 'true' or 'false'. The old if condition was therefore always true and the push job was always executed.