### PR TITLE
ci(lint): simplify the commitlint command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
 
       - name: Check for conventional commit style
         working-directory: ./dev_tooling
-        run: npx commitlint --from $(git merge-base main HEAD)
+        run: npx commitlint --from=origin/main


### PR DESCRIPTION
The commitlint command computes the difference between the current HEAD and the commit given to the --from argument. The computation is similar to 'git log <from>..HEAD'. Therefore it is not necessary to compute a merge base.