### PR TITLE
ci(deploy): remove some unused permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,9 +64,6 @@ jobs:
     if: needs.version.outputs.hasNextVersion == 'true'
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-
     steps:
       - name: Checkout of config repository
         uses: actions/checkout@v3


### PR DESCRIPTION
The job that updates the configuration repository only interacts with that repository. Therefore it doesn't need write permissions for the application repository.